### PR TITLE
Trim leading nbsp characters

### DIFF
--- a/applenews/helpers/AppleNewsHelper.php
+++ b/applenews/helpers/AppleNewsHelper.php
@@ -123,6 +123,7 @@ abstract class AppleNewsHelper
         // Trim unwanted whitespace within within block tags
         $blockTags = 'h1|h2|h3|h4|h5|h6|p|ul|ol|li|div';
         $html = preg_replace("/(<(?:{$blockTags}).*?>)\s*/is", "$1", $html);
+        $html = trim($html, chr(0xC2).chr(0xA0));
 
         $md = static::getHtmlConverter()->convert($html);
 


### PR DESCRIPTION
When publishing an article to Apple News, failed tasks will happen in the following scenario.

In rich text fields, empty headings like this:
```html
<h2> &nbsp;<h2>
```

Cause heading objects with missing text parameters in **article.json**:

```json
{
    "role": "heading",
    "layout": "headingLayout",
    "textStyle": "headingTextStyle"
}
```

The change in this pull request simply strips out non breaking space characters from the text string, which then prevents the ill-formatted empty heading component from being included output.